### PR TITLE
Add artifact URL to jvm_import tags

### DIFF
--- a/private/dependency_tree_parser.bzl
+++ b/private/dependency_tree_parser.bzl
@@ -219,8 +219,16 @@ def _generate_imports(repository_ctx, dep_tree, explicit_artifacts, neverlink_ar
             # 	deps = [
             # 		":org_hamcrest_hamcrest_core",
             # 	],
-            #   tags = ["maven_coordinates=org.hamcrest:hamcrest.library:1.3"],
-            target_import_string.append("\ttags = [\"maven_coordinates=%s\"]," % artifact["coord"])
+            #   tags = [
+            #       "maven_coordinates=org.hamcrest:hamcrest.library:1.3"],
+            #       "maven_url=https://repo1.maven.org/maven/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3.jar",
+            #   ],
+
+            target_import_string.append("\ttags = [")
+            target_import_string.append("\t\t\"maven_coordinates=%s\"," % artifact["coord"])
+            target_import_string.append("\t\t\"maven_url=%s\"," % artifact["url"])
+            target_import_string.append("\t],")
+
 
             # 6. If `neverlink` is True in the artifact spec, add the neverlink attribute to make this artifact
             #    available only as a compile time dependency.
@@ -232,7 +240,10 @@ def _generate_imports(repository_ctx, dep_tree, explicit_artifacts, neverlink_ar
             # 	deps = [
             # 		":org_hamcrest_hamcrest_core",
             # 	],
-            #   tags = ["maven_coordinates=org.hamcrest:hamcrest.library:1.3"],
+            #   tags = [
+            #       "maven_coordinates=org.hamcrest:hamcrest.library:1.3"],
+            #       "maven_url=https://repo1.maven.org/maven/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3.jar",
+            #   ],
             #   neverlink = True,
             if neverlink_artifacts.get(simple_coord):
                 target_import_string.append("\tneverlink = True,")
@@ -247,7 +258,10 @@ def _generate_imports(repository_ctx, dep_tree, explicit_artifacts, neverlink_ar
             #   deps = [
             #       ":org_hamcrest_hamcrest_core",
             #   ],
-            #   tags = ["maven_coordinates=org.hamcrest:hamcrest.library:1.3"],
+            #   tags = [
+            #       "maven_coordinates=org.hamcrest:hamcrest.library:1.3"],
+            #       "maven_url=https://repo1.maven.org/maven/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3.jar",
+            #   ],
             #   neverlink = True,
             #   testonly = True,
             if testonly_artifacts.get(simple_coord):
@@ -263,7 +277,10 @@ def _generate_imports(repository_ctx, dep_tree, explicit_artifacts, neverlink_ar
             # 	deps = [
             # 		":org_hamcrest_hamcrest_core",
             # 	],
-            #   tags = ["maven_coordinates=org.hamcrest:hamcrest.library:1.3"],
+            #   tags = [
+            #       "maven_coordinates=org.hamcrest:hamcrest.library:1.3"],
+            #       "maven_url=https://repo1.maven.org/maven/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3.jar",
+            #   ],
             #   neverlink = True,
             #   testonly = True,
             #   visibility = ["//visibility:public"],
@@ -280,7 +297,10 @@ def _generate_imports(repository_ctx, dep_tree, explicit_artifacts, neverlink_ar
             # 	deps = [
             # 		":org_hamcrest_hamcrest_core",
             # 	],
-            #   tags = ["maven_coordinates=org.hamcrest:hamcrest.library:1.3"],
+            #   tags = [
+            #       "maven_coordinates=org.hamcrest:hamcrest.library:1.3"],
+            #       "maven_url=https://repo1.maven.org/maven/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3.jar",
+            #   ],
             #   neverlink = True,
             #   testonly = True,
             # )


### PR DESCRIPTION
This change adds an artifact's download URL into the `tags` of `jvm_import` in the
external repository BUILD file. Previously, the `tags` only included
`maven_coordinate`, but they will now also include `maven_url`, storing the
artifact's URL. This information is intended to be consumed by an aspect that is
traversing a build graph for dependencies with the purpose of OSS identification
and license compliance.

This change will be used immediately by the VMware/rules_oss_audit project—soon
to be published on github.

**Testing Done:**
This change was tested with an example project from the [bazelbuild/examples](https://github.com/bazelbuild/examples) 
repository that uses rules_jvm_external to install Java dependencies. Testing steps:
1. Clone https://github.com/bazelbuild/examples
2. Run `cd java-maven`
3. Update the `WORKSPACE` file to use new rules_jvm_external
```
RULES_JVM_EXTERNAL_COMMIT = "2c3713585ce28244e36a6f08bc7a898c2ac54951"
RULES_JVM_EXTERNAL_SHA = "9a8661b8492c5fddface54a56938d8e7bff9b9f6f007e6823e2767d1a0cdfd71"
http_archive(
    name = "rules_jvm_external",
    sha256 = RULES_JVM_EXTERNAL_SHA,
    strip_prefix = "rules_jvm_external-%s" % RULES_JVM_EXTERNAL_COMMIT,
    url = "https://github.com/bazelbuild/rules_jvm_external/archive/%s.zip" % RULES_JVM_EXTERNAL_COMMIT,
)
```
4. Run `bazel build :java-maven`
5. Open `bazel-java-maven/external/maven/BUILD` to observe the java_import tags
now include `maven_url`. For example:
```
tags = [
    "maven_coordinates=org.checkerframework:checker-qual:2.8.1",
    "maven_url=https://jcenter.bintray.com/org/checkerframework/checker-qual/2.8.1/checker-qual-2.8.1.jar",
],
```