### PR TITLE
Add analysis test to check jvm_import tags

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -415,6 +415,16 @@ maven_install(
 )
 
 maven_install(
+    name = "jvm_import_test",
+    artifacts = [
+        "com.google.code.findbugs:jsr305:3.0.2",
+    ],
+    repositories = [
+        "https://jcenter.bintray.com/",
+    ],
+)
+
+maven_install(
     name = "starlark_aar_import_with_sources_test",
     artifacts = [
         "androidx.work:work-runtime:2.6.0",

--- a/tests/unit/jvm_import/BUILD
+++ b/tests/unit/jvm_import/BUILD
@@ -1,0 +1,17 @@
+# Copyright 2021 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load(":jvm_import_test.bzl", "jvm_import_test_suite")
+
+jvm_import_test_suite(name = "jvm_import_tests")

--- a/tests/unit/jvm_import/jvm_import_test.bzl
+++ b/tests/unit/jvm_import/jvm_import_test.bzl
@@ -1,0 +1,71 @@
+# Copyright 2019 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+This module contains a test suite for testing jvm_import
+"""
+
+load("@bazel_skylib//lib:unittest.bzl", "analysistest", "asserts")
+
+TagsInfo = provider(
+    doc = "Provider to propagate jvm_import's tags for testing purposes",
+    fields = {
+        "tags": "tags to be propagated for jvm_import's tests",
+    },
+)
+
+def _tags_propagator_impl(target, ctx):
+    tags = getattr(ctx.rule.attr, "tags")
+    return TagsInfo(tags = tags)
+
+tags_propagator = aspect(
+    doc = "Aspect that propagates tags to help with testing jvm_import",
+    attr_aspects = ["deps"],
+    implementation = _tags_propagator_impl,
+)
+
+def _does_jvm_import_have_tags_impl(ctx):
+    env = analysistest.begin(ctx)
+
+    expected_tags = [
+        "maven_coordinates=com.google.code.findbugs:jsr305:3.0.2",
+        "maven_url=https://jcenter.bintray.com/com/google/code/findbugs/jsr305/3.0.2/jsr305-3.0.2.jar",
+    ]
+
+    asserts.equals(env, ctx.attr.src[TagsInfo].tags, expected_tags)
+    return analysistest.end(env)
+
+does_jvm_import_have_tags_test = analysistest.make(
+    _does_jvm_import_have_tags_impl,
+    attrs = {
+        "src": attr.label(
+            doc = "Target to traverse for tags",
+            aspects = [tags_propagator],
+            mandatory = True,
+        ),
+    },
+)
+
+def jvm_import_test_suite(name):
+    does_jvm_import_have_tags_test(
+        name = "does_jvm_import_have_tags_test",
+        target_under_test = "@jvm_import_test//:com_google_code_findbugs_jsr305_3_0_2",
+        src = "@jvm_import_test//:com_google_code_findbugs_jsr305_3_0_2",
+    )
+    native.test_suite(
+        name = name,
+        tests = [
+            ":does_jvm_import_have_tags_test",
+        ],
+    )


### PR DESCRIPTION
This change adds an analysis test to verify the existence of the maven_url and
maven_coordinate tags in `jvm_import`, generated by maven_install. The analysis
test consumes an aspect, which propagates the tags with the `TagsInfo` provider.

The test suite, containing the single analysis test, can be run with:
```
% bazel test tests/unit/jvm_import:jvm_import_tests
```